### PR TITLE
Tikhonov Regularization Matrix

### DIFF
--- a/DETAILS.md
+++ b/DETAILS.md
@@ -121,7 +121,7 @@ To solve for the linear operators on the right-hand side of the preceding equati
 
 Where **1** is a _k_-vector of 1's.
 This problem decouples into _r_ independent least-squares problems, so it is relatively inexpensive to solve.
-The code allows for a Tikhonov regularization factor (the `reg` keyword argument for `ReducedModel.predict()`) to reduce numerical instabilities.
+The code allows for a Tikhonov regularization matrix (the `G` keyword argument for `ReducedModel.predict()`) to reduce numerical instabilities.
 
 It can be shown [\[1\]](https://www.sciencedirect.com/science/article/pii/S0045782516301104) that under some idealized assumptions, these inferred operators converge to the operators computed by explicit projection.
 The key idea, however, is that _the inferred operators can be cheaply computed without even knowing the full-order model_.

--- a/README.md
+++ b/README.md
@@ -168,14 +168,14 @@ The `has_inputs` argument is a boolean (`True` or `False`) denoting whether or n
 
 ##### Methods
 
-- `ReducedModel.fit(X, Xdot, Vr, U=None, reg=0)`: Compute the operators of the reduced-order model that best fit the data by solving a regularized least
+- `ReducedModel.fit(X, Xdot, Vr, U=None, G=0)`: Compute the operators of the reduced-order model that best fit the data by solving a regularized least
     squares problem. See [DETAILS.md](DETAILS.md) for more explanation.
 Parameters:
     - `X`: Snapshot matrix of solutions to the full-order model. Each column is one snapshot.
     - `Xdot`: Snapshot velocity of solutions to the full-order model. Each column is the velocity `dx / dt` for the corresponding column of `X`. See the [`pre`](#preprocessing-tools) submodule for some simple derivative approximation tools.
     - `Vr`: The basis for the linear reduced space on which the full-order model will be projected (for example, a POD basis matrix). Each column is a basis vector. The column space of `Vr` should be a good approximation of the column space of `X`. See [`pre.pod_basis()`](#preprocessing-tools) for an example of computing the POD basis.
     - `U`: Input matrix. Each column is the input for the corresponding column of `X`. Only required when `has_inputs=True`.
-    - `reg`: Tikhonov regularization factor for the least squares problem.
+    - `G`: Tikhonov regularization matrix for the least squares problem.
 
 - `ReducedModel.predict(x0, t, u=None, **options)`: Simulate the learned reduced-order model with `scipy.integrate.solve_ivp()`. Parameters:
     - `x0`: The initial condition, given in the original (high-dimensional) space.
@@ -216,8 +216,8 @@ None of these routines are novel, but they may be instructive for new Python use
 
 #### Postprocessing Tools
 
-The `post` submodule is a collection of common routines for computing the absolute and relative errors produced by an ROM approximation.
-Given a norm, "true" data _X_, and an approximation _Y_ to _X_, these errors are defined by <p align="center"><img src="https://latex.codecogs.com/svg.latex?\texttt{abs\_err}=||X-Y||,\qquad\texttt{rel\_err}=\frac{\texttt{abs\_err}}{||X||}=\frac{||X-Y||}{||X||}."/></p>
+The `post` submodule is a collection of common routines for computing the absolute and relative errors produced by a ROM approximation.
+Given a norm, "true" data _X_, and an approximation _Y_ to _X_, these errors are defined by <p align="center"><img src="https://latex.codecogs.com/svg.latex?\texttt{abs\_error}=||X-Y||,\qquad\texttt{rel\_error}=\frac{\texttt{abs\_error}}{||X||}=\frac{||X-Y||}{||X||}."/></p>
 
 - `post.discrete_error(X, Y)`: Compute the absolute and relative _l_<sup>_2_</sup>-norm errors between snapshot sets `X` and `Y`, assuming `Y` is an approximation to `X`.
 The _l_<sup>_2_</sup> norm is the usual Euclidean norm, <p align="center"><img src="https://latex.codecogs.com/svg.latex?||\mathbf{x}||_{\ell^2}=\sqrt{\sum_{i=1}^n|x_{i}|^2}."/></p>
@@ -231,11 +231,10 @@ The _L_<sup>_2_</sup> norm is approximated by the trapezoidal rule: <p align="ce
 These functions are helper routines that are used internally for `ReducedModel.fit()` or `ReducedModel.predict()`.
 See [DETAILS.md](DETAILS.md) for more mathematical explanation.
 
-- `utils.lstsq_reg(A, b, reg=0)`: Solve the Tikhonov-regularized ordinary least squares problem
-<p align="center"><img src="https://latex.codecogs.com/svg.latex?\underset{\mathbf{x}\in\mathbb{R}^n}{\text{min}}||A\mathbf{x}-\mathbf{b}||_{\ell^2}^2+\lambda||\mathbf{x}||_{\ell^2}^2,"/></p>
+- `utils.lstsq_reg(A, b, G=0)`: Solve the Tikhonov-regularized ordinary least squares problem
+<p align="center"><img src="https://latex.codecogs.com/svg.latex?\underset{\mathbf{x}\in\mathbb{R}^n}{\text{min}}||A\mathbf{x}-\mathbf{b}||_{\ell^2}^2+||G\mathbf{x}||_{\ell^2}^2,"/></p>
 
-  where λ is the regularization factor `reg`. If `b` is a matrix, call it _B_, then solve the regularized least squares problem
-<p align="center"><img src="https://latex.codecogs.com/svg.latex?\underset{X\in\mathbb{R}^{n\times%20n}}{\text{min}}||AX-B||_{F}^2+\lambda||X||_{F}^2,"/></p>
+  where _G_ is the regularization factor `reg`. If `b` is a matrix, solve the above problem for each column of `b`. If _G_ is a scalar, use the identity matrix times that scalar for the regularization matrix.
 
 -  `utils.kron_compact(x)`: Compute the column-wise compact Kronecker product of `x`.
 

--- a/examples/minimax.py
+++ b/examples/minimax.py
@@ -8,6 +8,17 @@ import numpy as np
 from sklearn.utils.extmath import randomized_svd
 
 
+def offdiag_penalizer(reg, r, m):
+    """Construct a list of regularization matrices that penalize the
+    off-diagonal elements of A and all elements of the remaining operators.
+    """
+    regI = _np.sqrt(reg) * _np.eye(r + r**2 + m + 1)
+    Gs = [regI] * r
+    for i in range(r):
+        Gs[r][r,r] = 0
+    return Gs
+
+
 def compute_randomized_svd(data, savepath, n_components=500):
     """Compute and save randomized SVD following
     https://scikit-learn.org/stable/modules/generated/sklearn.utils.extmath.randomized_svd.html

--- a/rom_operator_inference/_core.py
+++ b/rom_operator_inference/_core.py
@@ -87,7 +87,7 @@ class ReducedModel:
         self.modelform = modelform
         self.has_inputs = has_inputs
 
-    def fit(self, X, Xdot, Vr, U=None, reg=0):
+    def fit(self, X, Xdot, Vr, U=None, G=0):
         """Solve for the reduced model operators via regularized least squares.
 
         Parameters
@@ -105,9 +105,13 @@ class ReducedModel:
             Column-wise inputs corresponding to the snapshots. If m=1 (scalar
             input), then U may be a one-dimensional array.
 
-        reg : float
-            L2 regularization penalty. If nonzero, the least squares problem
-            takes the form min_{x}||Ax - b||_2^2 + reg*||x||_2^2.
+        G : (d,d) ndarray or float
+            Tikhonov regularization matrix. If nonzero, the least squares
+            problem problem takes the form min_{x} ||Ax - b||^2 + ||Gx||^2.
+            If a nonzero number is provided, the regularization matrix is
+            G * I (a scaled identity matrix). Here d is the dimension of the
+            data matrix for the least squares problem, e.g., d = r + m for a
+            linear model with inputs.
 
         Returns
         -------
@@ -166,7 +170,7 @@ class ReducedModel:
         d = D.shape[1]
 
         # Solve for the reduced-order model operators via least squares.
-        O, res = utils.lstsq_reg(D, Xdot_.T, reg)[0:2]
+        O, res = utils.lstsq_reg(D, Xdot_.T, G)[0:2]
         self.residual_ = np.sum(res)
 
         # Extract the reduced operators from O.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,41 +18,53 @@ def _test_lstq_reg_single(k,d,r):
     # VECTOR TEST
     x = la.lstsq(A, b)[0]
 
-    # Ensure that the least squares solution is the usual one when reg=0.
-    x_ = roi.utils.lstsq_reg(A, b, reg=0)[0]
+    # Ensure that the least squares solution is the usual one when G=0.
+    x_ = roi.utils.lstsq_reg(A, b, G=0)[0]
+    assert np.allclose(x, x_)
+
+    # Ensure that the least squares solution is the usual one when G=0 (matrix)
+    x_ = roi.utils.lstsq_reg(A, b, np.zeros((d,d)))[0]
     assert np.allclose(x, x_)
 
     # Check that the regularized least squares solution has decreased norm.
-    x_ = roi.utils.lstsq_reg(A, b, reg=2)[0]
+    x_ = roi.utils.lstsq_reg(A, b, G=2)[0]
     assert la.norm(x_) <= la.norm(x)
 
     # MATRIX TEST
     X = la.lstsq(A, B)[0]
 
-    # Ensure that the least squares solution is the usual one when reg=0.
-    X_ = roi.utils.lstsq_reg(A, B, reg=0)[0]
+    # Ensure that the least squares solution is the usual one when G=0.
+    X_ = roi.utils.lstsq_reg(A, B, G=0)[0]
     assert np.allclose(X, X_)
 
     # Check that the regularized least squares solution has decreased norm.
-    X_ = roi.utils.lstsq_reg(A, B, reg=2)[0]
+    X_ = roi.utils.lstsq_reg(A, B, G=2)[0]
     assert la.norm(X_) <= la.norm(X)
 
 
 def test_lstsq_reg(n_tests=20):
     """Test rom_operator_inference.utils.lstsq_reg()."""
+    A,B = np.random.random((2,10,10))
+
     # Negative regularization parameter not allowed.
     with pytest.raises(ValueError) as exc:
-        roi.utils.lstsq_reg(None, None, -1)
+        roi.utils.lstsq_reg(A, B, -1)
     assert exc.value.args[0] == "regularization parameter must be nonnegative"
 
     # b must be one- or two-dimensional
     with pytest.raises(ValueError) as exc:
-        roi.utils.lstsq_reg(None, np.random.random((2,2,2)))
+        roi.utils.lstsq_reg(A, np.random.random((2,2,2)))
     assert exc.value.args[0] == "parameter `b` must be one- or two-dimensional"
 
     with pytest.raises(ValueError) as exc:
-        roi.utils.lstsq_reg(None, np.array(5))
+        roi.utils.lstsq_reg(A, np.array(5))
     assert exc.value.args[0] == "parameter `b` must be one- or two-dimensional"
+
+    # Badly shaped regularization matrix.
+    with pytest.raises(ValueError) as exc:
+        roi.utils.lstsq_reg(A, B, np.random.random((5,5)))
+    assert exc.value.args[0] == \
+        "G must be (d,d) with d = number of columns of A"
 
     # Do individual tests.
     k, m = 200, 20


### PR DESCRIPTION
Change `utils.lstsq_reg()` so that the regularization parameter `reg`, now called `G`, can be a matrix or a float. If a matrix, then the least squares problem being solved is

`|| AX - B||_F^2 + ||GX||_F^2`

- If `G` is a float, then the regularization matrix is G*I (scaled identity matrix).
- If `G` is a list of regularization matrices G = [G1, G2, ..., Gr], then decouple the problem to

`||Ax_j - b_j||_2^2 + ||Gj x_j||_2^2`.